### PR TITLE
Updated module map for updated Swift Package Manager behavior

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,4 @@
 module CMySQLClient {
     header "shim.h"
-    link "mysqlclient"
     export *
 }


### PR DESCRIPTION
Hello,

When compiling your version of `swift-mysql`, i get this error:
![screen shot 2017-09-28 at 5 35 35 pm](https://user-images.githubusercontent.com/16155920/30991542-787bbfaa-a473-11e7-8216-1293febf6159.png)
 
I think this is caused by how Swift Package Manager new behavior for managing custom module maps for C language targets.